### PR TITLE
add PCM streaming support for text-to-speech

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,11 +1,11 @@
 import os
 from dotenv import load_dotenv
 from google import genai
-from chat_model.chatbot import (chat_api_sync, chat_stream_websocket, summarize_conversation, custom_topic_validation,
+from .chat_model.chatbot import (chat_api_sync, chat_stream_websocket, summarize_conversation, custom_topic_validation,
                                 chat_task, hint_to_users)
-from chat_model.emotion_detection import detect_emotion
-from audio_processing.transcriber import transcribe_audio_api, transcription_task
-from chat_model.text_to_speech import generate_tts_wav_api, tts_stream
+from .chat_model.emotion_detection import detect_emotion
+from .audio_processing.transcriber import transcribe_audio_api, transcription_task
+from .chat_model.text_to_speech import generate_tts_pcm_stream, tts_stream
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
@@ -17,17 +17,15 @@ from typing import List, Optional
 from statistics import mean
 from enum import Enum
 from deep_translator import GoogleTranslator
-from pronunciation_model.pronunciation_model import evaluate_pronunciation
-from chat_model.scoring.score_model import (evaluate_pause, evaluate_stutter, evaluate_transcription,
-                                            evaluate_vocabulary, evaluate_vocabulary_cefr)
-from utils.utils import clean_text
-from chat_model.scoring.vocab import evaluate_cefr_stats
+from .pronunciation_model.pronunciation_model import evaluate_pronunciation
+from .chat_model.scoring.score_model import (evaluate_pause, evaluate_stutter, evaluate_transcription,
+                                            evaluate_vocabulary_cefr)
+from .utils.utils import clean_text
 
 load_dotenv()
 app = FastAPI()
 gemini_key = os.getenv("GEMINI_KEY")
 client = genai.Client(api_key=gemini_key)
-load_dotenv()
 deepgram_key = os.getenv('DEEPGRAM_KEY')
 deepgram_client = DeepgramClient(deepgram_key)
 
@@ -183,10 +181,9 @@ async def transcribe_endpoint(input_data: AudioURLInput):
 async def chat_tts(input: TTSInput):
     try:
         cleaned_text = clean_text(input.text)
-        return StreamingResponse(
-            generate_tts_wav_api(cleaned_text, input.accent, input.gender, input.speed),
-            media_type="audio/wav"
-        )
+        gen = generate_tts_pcm_stream(cleaned_text, input.accent, input.gender, input.speed)
+        # We return raw PCM; the frontend decodes/plays it via AudioWorklet.
+        return StreamingResponse(gen, media_type="application/octet-stream")
     except Exception as e:
         return JSONResponse(content={"error": str(e)}, status_code=500)
 

--- a/src/chat_model/text_to_speech.py
+++ b/src/chat_model/text_to_speech.py
@@ -1,3 +1,4 @@
+import queue
 import time
 from dotenv import load_dotenv
 import wave
@@ -10,10 +11,10 @@ from deepgram import (
     DeepgramClient,
     SpeakWebSocketEvents,
     SpeakWSOptions,
-    SpeakOptions
 )
 from scipy.signal import resample_poly
 import numpy as np
+
 
 load_dotenv()
 deepgram_key = os.getenv('DEEPGRAM_KEY')
@@ -126,6 +127,83 @@ def generate_tts_wav_api(
 
     return audio_stream()
 
+
+def generate_tts_pcm_stream(text: str, accent: str = "american", gender: str = "feminine", speed: float = 1.0):
+    """
+    Yields raw 16-bit little-endian PCM (mono, 16 kHz) bytes as they arrive.
+    """
+    SAMPLE_RATE = 16000
+    q: "queue.Queue[bytes | None]" = queue.Queue(maxsize=64)
+    done_event = threading.Event()
+
+    # Pick Deepgram voice/model
+    model = "aura-2-amalthea-en"
+    if accent == "british" and gender == "feminine":
+        model = "aura-2-draco-en"
+    elif accent == "british" and gender == "masculine":
+        model = "aura-2-pandora-en"
+    elif accent == "australian":
+        model = "aura-2-hyperion-en"
+
+    # Callback for Deepgram audio chunks
+    def on_binary_data(_, data: bytes, **kwargs):
+        # Incoming bytes are linear16
+        audio = np.frombuffer(data, dtype=np.int16)
+
+        # Apply speed change by resampling if requested
+        if speed and abs(speed - 1.0) > 1e-6:
+            up = max(1, int(round(speed * 100)))
+            down = 100
+            audio = resample_poly(audio, up, down).astype(np.int16)
+
+        # Push bytes to queue (drop if the reader is too slow)
+        try:
+            q.put_nowait(audio.tobytes())
+        except queue.Full:
+            # Drop frames to keep latency bounded (no-seek stream)
+            pass
+
+    def on_close(**kwargs):
+        done_event.set()
+        try:
+            q.put_nowait(None)
+        except queue.Full:
+            pass
+
+    # Start the Deepgram streaming TTS
+    dg_connection = deepgram.speak.websocket.v("1")
+    dg_connection.on(SpeakWebSocketEvents.AudioData, on_binary_data)
+    dg_connection.on(SpeakWebSocketEvents.Close, on_close)
+
+    options = SpeakWSOptions(
+        model=model,
+        encoding="linear16",
+        sample_rate=SAMPLE_RATE,
+    )
+
+    if not dg_connection.start(options):
+        raise RuntimeError("Failed to start Deepgram connection")
+
+    # Send text and flush
+    dg_connection.send_text(text)
+    dg_connection.flush()
+
+    # The generator that FastAPI will iterate
+    def iterator():
+        # Optional: short leading silence to prime the player
+        yield (np.zeros(int(0.05 * SAMPLE_RATE), dtype=np.int16)).tobytes()
+
+        # Pull from queue until closed
+        while True:
+            chunk = q.get()
+            if chunk is None and done_event.is_set():
+                break
+            if chunk:
+                yield chunk
+
+        dg_connection.finish()
+
+    return iterator()
 
 
 def transform_speech(file_path, spoken_text, model="aura-2-amalthea-en" ):


### PR DESCRIPTION
* The `/chat_tts` endpoint now streams raw 16-bit PCM audio instead of WAV, using the new `generate_tts_pcm_stream` function. This allows the frontend to play audio directly via AudioWorklet, improving latency and compatibility. (`src/api.py` [src/api.pyL186-R187](diffhunk://#diff-d1f0f72ecbf1b8b4722b31c67c986a63dfaf0614dcf4ee3c77022ba76b38b3deL186-R187))

* Added `generate_tts_pcm_stream` to `src/chat_model/text_to_speech.py`, which streams PCM audio chunks from Deepgram in real time, applies speed adjustments, and handles voice selection based on accent and gender. (`src/chat_model/text_to_speech.py` [src/chat_model/text_to_speech.pyR131-R207](diffhunk://#diff-a43557939b6aa25eb0852d42c802eb87b36f551384f9965fb0ba70dae8667cccR131-R207))

* Uses a queue and event system to buffer and stream audio chunks efficiently, dropping frames if the consumer is too slow to maintain low latency. (`src/chat_model/text_to_speech.py` [src/chat_model/text_to_speech.pyR131-R207](diffhunk://#diff-a43557939b6aa25eb0852d42c802eb87b36f551384f9965fb0ba70dae8667cccR131-R207))